### PR TITLE
implement apply algorithm with helper function split

### DIFF
--- a/src/dd.mli
+++ b/src/dd.mli
@@ -89,6 +89,3 @@ val equal : t -> t -> bool
 val id : t -> int
 
 
-(** The index of a diagram is the index of its top-most variable, or -1 if the
-    diagram is a leaf. *)
-val index : t -> int

--- a/src/idd.mli
+++ b/src/idd.mli
@@ -11,7 +11,6 @@ type manager
 
 val manager : unit -> manager
 
-
 (** {2 Constructors} *)
 
 (** The identity relation. *)
@@ -24,6 +23,9 @@ val empty : t
     [var = true], and like [lo] when [var = false]. *)
 val branch : manager -> Var.t -> t -> t -> t
 
+(** [apply mgr op t0 t1] is [t] such that 
+    [Bool.equal (op (eval t0 env n) (eval t1 env n)) (eval t env n)] *)
+val apply : manager -> (bool -> bool -> bool) -> t -> t -> t
 
 (** {2 Boolean operations} *)
 
@@ -36,8 +38,13 @@ val equal : t -> t -> bool
 (** {2 Semantics} *)
 
 (** [eval tree env n] evaluates idd [tree] in environment [env] where the
-    variable indices are 0,...,[n]-1 *)
+    variable indices are 0,...,[n-1] *)
 val eval : t -> (Var.t -> bool) -> int -> bool
+
+(** The index of a diagram is the index of its top-most variable, or -1 if the
+    diagram is a leaf. *)
+val index : t -> int
+
 
 module Rel : Algebra.KAT with
   type b := Bdd.t and

--- a/src/var.ml
+++ b/src/var.ml
@@ -10,6 +10,7 @@ module T = struct
 end
 include T
 
+let leaf_idx = -1
 
 let inp (id : int) : t = { id = id*2 }
 let out (id : int) : t = { id = id*2 + 1 }
@@ -30,3 +31,7 @@ let is_in_out_pair inp out : bool =
 
 let index (t : t) : int = t.id / 2
 
+let closer_to_root (v0 : t) (v1 : t) : bool = 
+  not (is_in_out_pair v1 v0) && (is_in_out_pair v0 v1 || v0.id > v1.id)
+
+let idx_closer_to_root (idx0 : int) (idx1 : int) : bool = idx0 > idx1

--- a/src/var.mli
+++ b/src/var.mli
@@ -3,6 +3,7 @@
 
 type t [@@deriving compare, sexp, hash, eq]
 
+val leaf_idx : int
 
 val inp : int -> t
 val out : int -> t
@@ -14,3 +15,11 @@ val index : t -> int
 
 val to_out : t -> t
 val is_in_out_pair : t -> t -> bool
+
+(** [closer_to_root v0 v1] is whether or not, if [v0] and [v1] were to appear
+    in the same, ordered idd, [v0] would appear closer to the root *)
+val closer_to_root : t -> t -> bool 
+
+(** [closer_to_root idx0 idx1] is whether or not a variable with index [idx0]
+    goes closer to the root of an ordered idd than a variable with index [idx1] *)
+val idx_closer_to_root : int -> int -> bool


### PR DESCRIPTION
I moved the index function you added from dd.mli to idd.mli because my implementation calls Var.index, which knows about input/output variables, and I thought regular dds might not want to distinguish between input and output variables. Lmk if I should move it back